### PR TITLE
Added button type to addToCart button; required by firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ public
 *.log
 yarn.lock
 gatsby-node.old.js
+package-lock.json

--- a/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
@@ -184,7 +184,7 @@ const Product = ({ data: { product, suggestions } }) => {
                     </>
                   )}
                   <AddToCart
-                    type="submit"
+                    type="button"
                     variantId={productVariant.storefrontId}
                     quantity={quantity}
                     available={available}


### PR DESCRIPTION
The demo does not allow adding items to cart on firefox because of type="submit"