### PR TITLE
Fix Disabled Checkout when GATSBY_DEMO_STORE=false

### DIFF
--- a/src/components/cart.jsx
+++ b/src/components/cart.jsx
@@ -110,7 +110,7 @@ const Cart = ({ isOpen, onClose, btnRef }) => {
                     )}
                   </Box>
                   <Spacer as={GridItem} colSpan="2" axis="vertical" size={6} />
-                  {isDemoStore ? (
+                  {isDemoStore === true ? (
                     <Button
                       gridColumn="span 2/span 2"
                       colorScheme={primaryColorScheme}


### PR DESCRIPTION
the **typeof isDemoStore** evaluates to string. because of this, line 113 will always evaluate to true weather the value of **isDemoStore** is true or false. so in order for the checkout button to NOT BE DISABLED we need to explicitly check if the value of **isDemoStore** is actually true