### PR TITLE
chore: remove css-modules warnings and improve css perf

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,17 +1,1 @@
-// @ts-check
-exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
-  const webpackConfig = getConfig()
 
-  // We bundle all CSS on every page to ensure CSS specificity is always correct and
-  // that our users do not have to worry about how they write CSS. With CSS modules, we know all our CSS is scoped to a page.
-  // We can remove the default behavior from Gatsby to only include the used CSS.
-  if (
-    webpackConfig.optimization &&
-    webpackConfig.optimization.splitChunks &&
-    webpackConfig.optimization.splitChunks.styles
-  ) {
-    delete webpackConfig.optimization.splitChunks.styles
-
-    actions.replaceWebpackConfig(webpackConfig)
-  }
-}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,17 @@
 // @ts-check
-exports.onCreateBabelConfig = ({ actions }) => {
-  actions.setBabelPlugin({
-    name: `babel-plugin-react-icons`,
-    options: {},
-  })
+exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
+  const webpackConfig = getConfig()
+
+  // We bundle all CSS on every page to ensure CSS specificity is always correct and
+  // that our users do not have to worry about how they write CSS. With CSS modules, we know all our CSS is scoped to a page.
+  // We can remove the default behavior from Gatsby to only include the used CSS.
+  if (
+    webpackConfig.optimization &&
+    webpackConfig.optimization.splitChunks &&
+    webpackConfig.optimization.splitChunks.styles
+  ) {
+    delete webpackConfig.optimization.splitChunks.styles
+
+    actions.replaceWebpackConfig(webpackConfig)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "@react-icons/all-files": "^4.1.0",
+    "react-icons": "^4.1.0",
     "@sindresorhus/slugify": "^1.1.0",
-    "babel-plugin-react-icons": "^0.1.1",
     "gatsby": "next",
     "gatsby-plugin-gatsby-cloud": "next",
     "gatsby-plugin-image": "next",

--- a/src/components/add-to-cart.jsx
+++ b/src/components/add-to-cart.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { addToCart as addToCartStyle } from "./add-to-cart.module.css"
 import { StoreContext } from "../context/store-context"
+import { addToCart as addToCartStyle } from "./add-to-cart.module.css"
 
 export function AddToCart({ variantId, quantity, available, ...props }) {
   const { addVariantToCart, loading } = React.useContext(StoreContext)

--- a/src/components/cart-button.jsx
+++ b/src/components/cart-button.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
-import { cartButton, badge } from "./cart-button.module.css"
-import CartIcon from "../icons/cart"
 import { Link } from "gatsby"
+import CartIcon from "../icons/cart"
+import { cartButton, badge } from "./cart-button.module.css"
 
 export function CartButton({ quantity }) {
   return (

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import Logo from "../icons/logo"
 import {
   footerStyle,
   copyright,
@@ -6,7 +7,6 @@ import {
   blurb,
   logos,
 } from "./footer.module.css"
-import Logo from "../icons/logo"
 
 export function Footer() {
   return (

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,11 +1,4 @@
 import * as React from "react"
-import {
-  header,
-  container,
-  logo as logoCss,
-  searchButton,
-  nav,
-} from "./header.module.css"
 import { Link } from "gatsby"
 import { StoreContext } from "../context/store-context"
 import Logo from "../icons/logo"
@@ -13,6 +6,13 @@ import { Navigation } from "./navigation"
 import { CartButton } from "./cart-button"
 import SearchIcon from "../icons/search"
 import { Toast } from "./toast"
+import {
+  header,
+  container,
+  logo as logoCss,
+  searchButton,
+  nav,
+} from "./header.module.css"
 
 export function Header() {
   const { checkout, loading, didJustAddToCart } = React.useContext(StoreContext)

--- a/src/components/line-item.jsx
+++ b/src/components/line-item.jsx
@@ -1,11 +1,4 @@
 import * as React from "react"
-import {
-  title,
-  remove,
-  variant,
-  totals,
-  priceColumn,
-} from "./line-item.module.css"
 import debounce from "lodash.debounce"
 import { StoreContext } from "../context/store-context"
 import { formatPrice } from "../utils/format-price"
@@ -13,6 +6,13 @@ import { GatsbyImage } from "gatsby-plugin-image"
 import { getShopifyImage } from "gatsby-source-shopify"
 import DeleteIcon from "../icons/delete"
 import { NumericInput } from "./numeric-input"
+import {
+  title,
+  remove,
+  variant,
+  totals,
+  priceColumn,
+} from "./line-item.module.css"
 
 export function LineItem({ item }) {
   const {

--- a/src/components/more-button.jsx
+++ b/src/components/more-button.jsx
@@ -1,6 +1,7 @@
 import * as React from "react"
-import { moreButton } from "./more-button.module.css"
 import { Link } from "gatsby"
+import { moreButton } from "./more-button.module.css"
+
 export function MoreButton({ className, ...props }) {
   return <Link className={[className, moreButton].join(" ")} {...props} />
 }

--- a/src/components/navigation.jsx
+++ b/src/components/navigation.jsx
@@ -1,7 +1,7 @@
 import { graphql, useStaticQuery, Link } from "gatsby"
 import * as React from "react"
-import { navStyle, navLink, activeLink } from "./navigation.module.css"
 import slugify from "@sindresorhus/slugify"
+import { navStyle, navLink, activeLink } from "./navigation.module.css"
 
 export function Navigation({ className }) {
   const {

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { heading, paragraph, container } from "./404.module.css"
 import { Layout } from "../components/layout"
+import { heading, paragraph, container } from "./404.module.css"
 
 export default function NotFoundPage() {
   return (

--- a/src/pages/cart.jsx
+++ b/src/pages/cart.jsx
@@ -1,5 +1,9 @@
 import * as React from "react"
 import { Link } from "gatsby"
+import { Layout } from "../components/layout"
+import { StoreContext } from "../context/store-context"
+import { LineItem } from "../components/line-item"
+import { formatPrice } from "../utils/format-price"
 import {
   table,
   wrap,
@@ -16,11 +20,6 @@ import {
   emptyStateLink,
   title,
 } from "./cart.module.css"
-
-import { Layout } from "../components/layout"
-import { StoreContext } from "../context/store-context"
-import { LineItem } from "../components/line-item"
-import { formatPrice } from "../utils/format-price"
 
 export default function CartPage() {
   const { checkout, loading } = React.useContext(StoreContext)

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import { container, intro, callOut } from "./index.module.css"
-import { Layout } from "../components/layout"
 import { graphql } from "gatsby"
+import { Layout } from "../components/layout"
 import { ProductListing } from "../components/product-listing"
+import { container, intro, callOut } from "./index.module.css"
 
 export const query = graphql`
   query {

--- a/src/pages/products/index.jsx
+++ b/src/pages/products/index.jsx
@@ -1,10 +1,10 @@
 import * as React from "react"
-import { title } from "./index.module.css"
 import { graphql } from "gatsby"
 import { Layout } from "../../components/layout"
 import { ProductListing } from "../../components/product-listing"
 import { Seo } from "../../components/seo"
 import { MoreButton } from "../../components/more-button"
+import { title } from "./index.module.css"
 
 export default function Products({ data: { products } }) {
   return (

--- a/src/pages/products/vendor/{ShopifyProduct.vendor}.jsx.example
+++ b/src/pages/products/vendor/{ShopifyProduct.vendor}.jsx.example
@@ -1,11 +1,11 @@
 import * as React from "react"
-import { title } from "../index.module.css"
 import { graphql } from "gatsby"
 import { Layout } from "../../../components/layout"
 import { ProductListing } from "../../../components/product-listing"
 import { Seo } from "../../../components/seo"
 import slugify from "@sindresorhus/slugify"
 import { MoreButton } from "../../../components/more-button"
+import { title } from "../index.module.css"
 
 export default function Products({
   data: { products },

--- a/src/pages/products/{ShopifyProduct.productType}/index.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/index.jsx
@@ -1,11 +1,11 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 import { Layout } from "../../../components/layout"
-import { title } from "../index.module.css"
 import { ProductListing } from "../../../components/product-listing"
 import { Seo } from "../../../components/seo"
 import slugify from "@sindresorhus/slugify"
 import { MoreButton } from "../../../components/more-button"
+import { title } from "../index.module.css"
 
 export default function ProductTypeIndex({
   data: { products },

--- a/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
@@ -1,5 +1,14 @@
 import * as React from "react"
 import { graphql, Link } from "gatsby"
+import { Layout } from "../../../components/layout"
+import isEqual from "lodash.isequal"
+import { GatsbyImage, getSrc } from "gatsby-plugin-image"
+import { StoreContext } from "../../../context/store-context"
+import { AddToCart } from "../../../components/add-to-cart"
+import { NumericInput } from "../../../components/numeric-input"
+import { formatPrice } from "../../../utils/format-price"
+import { Seo } from "../../../components/seo"
+import { CgChevronRight as ChevronIcon } from "react-icons/cg"
 import {
   productBox,
   container,
@@ -17,15 +26,6 @@ import {
   metaSection,
   productDescription,
 } from "./product-page.module.css"
-import isEqual from "lodash.isequal"
-import { GatsbyImage, getSrc } from "gatsby-plugin-image"
-import { Layout } from "../../../components/layout"
-import { StoreContext } from "../../../context/store-context"
-import { AddToCart } from "../../../components/add-to-cart"
-import { NumericInput } from "../../../components/numeric-input"
-import { formatPrice } from "../../../utils/format-price"
-import { Seo } from "../../../components/seo"
-import { CgChevronRight as ChevronIcon } from "react-icons/cg"
 
 export default function Product({ data: { product, suggestions } }) {
   const {

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -3,18 +3,21 @@ import { useLocation } from "@reach/router"
 import { graphql } from "gatsby"
 import slugify from "@sindresorhus/slugify"
 import { CgChevronRight, CgChevronLeft } from "react-icons/cg"
+import { Layout } from "../components/layout"
 import CrossIcon from "../icons/cross"
 import SortIcon from "../icons/sort"
 import FilterIcon from "../icons/filter"
 import SearchIcon from "../icons/search"
-import { Layout } from "../components/layout"
 import { ProductCard } from "../components/product-card"
-
 import {
   getValuesFromQueryString,
   useProductSearch,
   useSearchPagination,
 } from "../utils/hooks"
+import { getCurrencySymbol } from "../utils/format-price"
+import { Spinner } from "../components/progress"
+import { Filters } from "../components/filters"
+import { SearchProvider } from "../context/search-provider"
 import {
   main,
   search,
@@ -37,10 +40,6 @@ import {
   activeFilters,
   filterWrap,
 } from "./search-page.module.css"
-import { getCurrencySymbol } from "../utils/format-price"
-import { Spinner } from "../components/progress"
-import { Filters } from "../components/filters"
-import { SearchProvider } from "../context/search-provider"
 
 export const query = graphql`
   query {


### PR DESCRIPTION
Some cleanup in the starter:
- Remove @react-icons/all package as it's not necessary with V3 anymore. We now do tree-shaking on a page level, not app level.
- Remove CSS module warnings
```
warn chunk commons [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[1]!./node_modules/gat
sby/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[2]!./src/components/to
ast.module.css
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[1]!./node_modules/gat
sby/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[2]!./src/pages/product
s/index.module.css
   - couldn't fulfill desired order of chunk group(s) component---src-pages-products-index-jsx
   - while fulfilling desired order of chunk group(s)
component---src-pages-products-shopify-product-product-type-index-jsx
warn chunk commons [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[1]!./node_modules/gat
sby/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[2]!./src/components/fo
oter.module.css
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[1]!./node_modules/gat
sby/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[9].oneOf[0].use[2]!./src/pages/product
s/index.module.css
   - couldn't fulfill desired order of chunk group(s) component---src-pages-products-index-jsx
   - while fulfilling desired order of chunk group(s)
component---src-pages-products-shopify-product-product-type-index-jsx
```