### PR TITLE
feat: add scrollbar to checkbox filter lists on the search page

### DIFF
--- a/src/components/check-filter.jsx
+++ b/src/components/check-filter.jsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import {
   filter,
   summary,
+  filterOptions,
   clearButton,
   selectedLabel,
   checkbox,
@@ -48,21 +49,23 @@ export function CheckFilter({
           </div>
         </summary>
       )}
-      {items.map((item) => (
-        <label
-          className={selectedItems.includes(item) ? selectedLabel : undefined}
-          key={item}
-        >
-          <input
-            type="checkbox"
-            className={checkbox}
-            onChange={toggleItem}
-            value={item}
-            checked={selectedItems.includes(item)}
-          />{" "}
-          {item || "None"}
-        </label>
-      ))}
+      <div className={filterOptions}>
+        {items.map((item) => (
+          <label
+            className={selectedItems.includes(item) ? selectedLabel : undefined}
+            key={item}
+          >
+            <input
+              type="checkbox"
+              className={checkbox}
+              onChange={toggleItem}
+              value={item}
+              checked={selectedItems.includes(item)}
+            />{" "}
+            {item || "None"}
+          </label>
+        ))}
+      </div>
     </details>
   )
 }

--- a/src/components/check-filter.module.css
+++ b/src/components/check-filter.module.css
@@ -36,6 +36,10 @@
   color: transparent;
 }
 
+.filter summary::-webkit-details-marker {
+  display: none;
+}
+
 .summary {
   display: flex;
   align-items: center;

--- a/src/components/check-filter.module.css
+++ b/src/components/check-filter.module.css
@@ -37,7 +37,7 @@
 }
 
 .filter summary::-webkit-details-marker {
-  display: none;
+  display: none; /* hide the summary arrow on safari */
 }
 
 .summary {

--- a/src/components/check-filter.module.css
+++ b/src/components/check-filter.module.css
@@ -47,7 +47,7 @@
 }
 
 .filter-options {
-  height: 200px;
+  max-height: 200px;
   overflow: scroll;
 }
 

--- a/src/components/check-filter.module.css
+++ b/src/components/check-filter.module.css
@@ -42,6 +42,11 @@
   justify-content: space-between;
 }
 
+.filter-options {
+  height: 200px;
+  overflow: scroll;
+}
+
 .clearButton {
   color: var(--text-color-secondary);
   font-size: var(--text-sm);

--- a/src/components/filters.module.css
+++ b/src/components/filters.module.css
@@ -28,6 +28,10 @@
   display: none;
 }
 
+.priceFilterStyle summary::-webkit-details-marker {
+  display: none; /* hide the summary arrow on safari */
+}
+
 .priceFilterStyle summary {
   list-style: none;
 }


### PR DESCRIPTION
Clubhouse ticket: [30146](https://app.clubhouse.io/gatsbyjs/story/30146/brand-list-is-long-making-the-sidebar-significantly-longer-than-the-content-area)

Adds a scrollbar to the list of filter checkboxes when it gets too long.

![Screen Shot 2021-05-04 at 2 50 54 PM (2)](https://user-images.githubusercontent.com/3609989/117074491-3f572d00-ace8-11eb-896c-6810ad512733.png)
