### PR TITLE
fix: only add overflow-y

### DIFF
--- a/src/components/check-filter.module.css
+++ b/src/components/check-filter.module.css
@@ -48,7 +48,7 @@
 
 .filter-options {
   max-height: 200px;
-  overflow: scroll;
+  overflow-y: auto;
 }
 
 .clearButton {


### PR DESCRIPTION
Remove ugly borders from windows machines. Now it only shows vertically and when it's to large