### PR TITLE
Accessibility fixes (cart, product, 404)

### DIFF
--- a/src/components/line-item.jsx
+++ b/src/components/line-item.jsx
@@ -91,7 +91,7 @@ export function LineItem({ item }) {
         )}
       </td>
       <td>
-        <h4 className={title}>{item.title}</h4>
+        <h2 className={title}>{item.title}</h2>
         <div className={variant}>
           {item.variant.title === "Default Title" ? "" : item.variant.title}
         </div>
@@ -101,7 +101,6 @@ export function LineItem({ item }) {
           </button>
         </div>
       </td>
-
       <td className={priceColumn}>{price}</td>
       <td>
         <NumericInput

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -5,12 +5,12 @@ import { heading, paragraph, container } from "./404.module.css"
 export default function NotFoundPage() {
   return (
     <Layout>
-      <main className={container}>
-        <h2 className={heading}>Page Not Found</h2>
+      <div className={container}>
+        <h1 className={heading}>Page Not Found</h1>
         <p className={paragraph}>
           Sorry, we couldn't find what you were looking for
         </p>
-      </main>
+      </div>
     </Layout>
   )
 }

--- a/src/pages/404.module.css
+++ b/src/pages/404.module.css
@@ -2,9 +2,9 @@
   width: 100%;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  margin-top: 24px;
+  padding-left: var(--size-gutter-raw);
+  padding-right: var(--size-gutter-raw);
+  margin-top: var(--space-2xl);
 }
 
 .heading {
@@ -15,5 +15,5 @@
 
 .paragraph {
   font-size: var(--text-lg);
-  margin-top: 24px;
+  margin-top: var(--space-2xl);
 }

--- a/src/pages/cart.jsx
+++ b/src/pages/cart.jsx
@@ -31,7 +31,7 @@ export default function CartPage() {
 
   return (
     <Layout>
-      <main className={wrap}>
+      <div className={wrap}>
         {emptyCart ? (
           <div className={emptyStateContainer}>
             <h1 className={emptyStateHeading}>Your cart is empty</h1>
@@ -115,7 +115,7 @@ export default function CartPage() {
             </button>
           </>
         )}
-      </main>
+      </div>
     </Layout>
   )
 }

--- a/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
@@ -111,111 +111,105 @@ export default function Product({ data: { product, suggestions } }) {
           image={getSrc(firstImage.gatsbyImageData)}
         />
       ) : undefined}
-      <main>
-        <div className={container}>
-          <div className={productBox}>
-            {hasImages && (
-              <div className={productImageWrapper}>
-                <div
-                  role="group"
-                  aria-label="gallery"
-                  aria-describedby="instructions"
-                >
-                  <ul className={productImageList}>
-                    {images.map((image, index) => (
-                      <li
-                        key={`product-image-${image.id}`}
-                        className={productImageListItem}
-                      >
-                        <GatsbyImage
-                          objectFit="contain"
-                          loading={index === 0 ? "eager" : "lazy"}
-                          alt={
-                            image.altText
-                              ? image.altText
-                              : `Product Image of ${title} #${index + 1}`
-                          }
-                          image={image.gatsbyImageData}
-                        />
-                      </li>
-                    ))}
-                  </ul>
+      <div className={container}>
+        <div className={productBox}>
+          {hasImages && (
+            <div className={productImageWrapper}>
+              <div
+                role="group"
+                aria-label="gallery"
+                aria-describedby="instructions"
+              >
+                <ul className={productImageList}>
+                  {images.map((image, index) => (
+                    <li
+                      key={`product-image-${image.id}`}
+                      className={productImageListItem}
+                    >
+                      <GatsbyImage
+                        objectFit="contain"
+                        loading={index === 0 ? "eager" : "lazy"}
+                        alt={
+                          image.altText
+                            ? image.altText
+                            : `Product Image of ${title} #${index + 1}`
+                        }
+                        image={image.gatsbyImageData}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              {hasMultipleImages && (
+                <div className={scrollForMore}>
+                  <span aria-hidden="true">←</span> scroll for more{" "}
+                  <span aria-hidden="true">→</span>
                 </div>
-                {hasMultipleImages && (
-                  <div className={scrollForMore}>
-                    <span aria-hidden="true">←</span> scroll for more{" "}
-                    <span aria-hidden="true">→</span>
+              )}
+            </div>
+          )}
+          {!hasImages && (
+            <span className={noImagePreview}>No Preview image</span>
+          )}
+          <div>
+            <div className={breadcrumb}>
+              <Link to={product.productTypeSlug}>{product.productType}</Link>
+              <ChevronIcon size={12} />
+            </div>
+            <h1 className={header}>{title}</h1>
+            <p className={productDescription}>{description}</p>
+            <h2 className={priceValue}>
+              <span>{price}</span>
+            </h2>
+            <fieldset className={optionsWrapper}>
+              {hasVariants &&
+                options.map(({ id, name, values }, index) => (
+                  <div className={selectVariant} key={id}>
+                    <select
+                      aria-label="Variants"
+                      onChange={(event) => handleOptionChange(index, event)}
+                    >
+                      <option value="">{`Select ${name}`}</option>
+                      {values.map((value) => (
+                        <option value={value} key={`${name}-${value}`}>
+                          {value}
+                        </option>
+                      ))}
+                    </select>
                   </div>
-                )}
-              </div>
-            )}
-            {!hasImages && (
-              <span className={noImagePreview}>No Preview image</span>
-            )}
-
-            <div>
-              <div className={breadcrumb}>
+                ))}
+            </fieldset>
+            <div className={addToCartStyle}>
+              <NumericInput
+                aria-label="Quantity"
+                onIncrement={() => setQuantity((q) => Math.min(q + 1, 20))}
+                onDecrement={() => setQuantity((q) => Math.max(1, q - 1))}
+                onChange={(event) => setQuantity(event.currentTarget.value)}
+                value={quantity}
+                min="1"
+                max="20"
+              />
+              <AddToCart
+                variantId={productVariant.storefrontId}
+                quantity={quantity}
+                available={available}
+              />
+            </div>
+            <div className={metaSection}>
+              <span className={labelFont}>Type</span>
+              <span className={tagList}>
                 <Link to={product.productTypeSlug}>{product.productType}</Link>
-                <ChevronIcon size={12} />
-              </div>
-              <h1 className={header}>{title}</h1>
-              <p className={productDescription}>{description}</p>
-              <h2 className={priceValue}>
-                <span>{price}</span>
-              </h2>
-              <fieldset className={optionsWrapper}>
-                {hasVariants &&
-                  options.map(({ id, name, values }, index) => (
-                    <div className={selectVariant} key={id}>
-                      <select
-                        aria-label="Variants"
-                        onChange={(event) => handleOptionChange(index, event)}
-                      >
-                        <option value="">{`Select ${name}`}</option>
-                        {values.map((value) => (
-                          <option value={value} key={`${name}-${value}`}>
-                            {value}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  ))}
-              </fieldset>
-              <div className={addToCartStyle}>
-                <NumericInput
-                  aria-label="Quantity"
-                  onIncrement={() => setQuantity((q) => Math.min(q + 1, 20))}
-                  onDecrement={() => setQuantity((q) => Math.max(1, q - 1))}
-                  onChange={(event) => setQuantity(event.currentTarget.value)}
-                  value={quantity}
-                  min="1"
-                  max="20"
-                />
-                <AddToCart
-                  variantId={productVariant.storefrontId}
-                  quantity={quantity}
-                  available={available}
-                />
-              </div>
-              <div className={metaSection}>
-                <span className={labelFont}>Type</span>
-                <span className={tagList}>
-                  <Link to={product.productTypeSlug}>
-                    {product.productType}
-                  </Link>
-                </span>
-
-                <span className={labelFont}>Tags</span>
-                <span className={tagList}>
-                  {product.tags.map((tag) => (
-                    <Link to={`/search?t=${tag}`}>{tag}</Link>
-                  ))}
-                </span>
-              </div>
+              </span>
+              <span className={labelFont}>Tags</span>
+              <span className={tagList}>
+                {product.tags.map((tag) => (
+                  <Link to={`/search?t=${tag}`}>{tag}</Link>
+                ))}
+              </span>
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </Layout>
   )
 }

--- a/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
@@ -141,7 +141,7 @@ export default function Product({ data: { product, suggestions } }) {
                 </ul>
               </div>
               {hasMultipleImages && (
-                <div className={scrollForMore}>
+                <div className={scrollForMore} id="instructions">
                   <span aria-hidden="true">←</span> scroll for more{" "}
                   <span aria-hidden="true">→</span>
                 </div>


### PR DESCRIPTION
Various fixes, mostly `main` landmark related — `<Layout>` always provides a `main` landmark via `<SkipNavContent>`.


**Cart**

* Heading levels should only increase by one (8acef68)
* `main` landmark (e7326b3)

**Product** page

* `main` landmark (81fff6e)
* ARIA attributes must conform to valid values (9fb2c1c) — brings back the missing `id="instructions"` that corresponds to the product image (gallery's) `aria-describedby`

**404** page

* `main` landmark, level-one heading (98a79bf)
* Fix page gutter; use CSS variables (94c2981)