### PR TITLE
update to v5 and remove apiKey references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # See how to get these values here: https://gatsby.dev/shopify-api-keys
 GATSBY_STOREFRONT_ACCESS_TOKEN=XXX
 GATSBY_SHOPIFY_STORE_URL=your-url.myshopify.com
-SHOPIFY_API_KEY=XXX
 SHOPIFY_SHOP_PASSWORD=shppa_xxxxx
 GOOGLE_ANALYTICS_ID=XXX

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,7 +18,6 @@ module.exports = {
     {
       resolve: "gatsby-source-shopify",
       options: {
-        apiKey: process.env.SHOPIFY_API_KEY,
         password: process.env.SHOPIFY_SHOP_PASSWORD,
         storeUrl: process.env.GATSBY_SHOPIFY_STORE_URL,
         shopifyConnections: ["collections"],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gatsby-plugin-sharp": "^3.4.1",
     "gatsby-plugin-sitemap": "^4.0.0",
     "gatsby-source-filesystem": "^3.4.0",
-    "gatsby-source-shopify": "rc",
+    "gatsby-source-shopify": "^5.0.1",
     "gatsby-transformer-sharp": "^3.4.0",
     "isomorphic-fetch": "^3.0.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Updating to v5. We no longer use `apiKey` in this plugin version so we also remove references to the `apiKey` here.