### PR TITLE
Updated url for api key instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# See how to get these values here: https://gatsby.dev/shopify-api-keys
+# See how to get these values here: https://shopify.dev/apps/auth/basic-http#generate-credentials-from-the-shopify-admin
 GATSBY_STOREFRONT_ACCESS_TOKEN=XXX
 GATSBY_SHOPIFY_STORE_URL=your-url.myshopify.com
 SHOPIFY_SHOP_PASSWORD=shppa_xxxxx


### PR DESCRIPTION
The older URL is now deprecated and sends the user to a repository that has been deprecated. 

A link is provided for the new repo but I did not find the information on how to get the API keys