### PR TITLE
small fixes

### DIFF
--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -42,7 +42,20 @@ import {
 
 const DEFAULT_PRODUCTS_PER_PAGE = 24
 
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
+}
+
 export async function getServerData({ query, ...rest }) {
+  if(isEmpty(query)) {
+    return {
+      props: {
+        query: { q: "" },
+        products: [],
+      }
+    };
+  }
+
   const { getSearchResults } = require("../utils/search")
   const products = await getSearchResults({
     query,
@@ -75,7 +88,7 @@ function SearchPage({
   location,
 }) {
   // These default values come from the page query string
-  const queryParams = getValuesFromQuery(location.search || serverData.query)
+  const queryParams = getValuesFromQuery(location.search || serverData?.query || "");
 
   const [filters, setFilters] = React.useState(queryParams)
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -105,7 +118,7 @@ function SearchPage({
     sortKey,
     false,
     DEFAULT_PRODUCTS_PER_PAGE,
-    serverData.products,
+    serverData && serverData.products.length ? serverData.products : [],
     initialFilters
   )
 
@@ -146,9 +159,10 @@ function SearchPage({
     }
   }, [location.hash, hasNextPage, fetchNextPage])
 
-  const currencyCode = getCurrencySymbol(
-    serverData.products?.[0]?.node?.priceRangeV2?.minVariantPrice?.currencyCode
-  )
+  const currencySymbol = serverData && serverData.products.length
+    ? serverData.products?.[0]?.node?.priceRangeV2?.minVariantPrice?.currencyCode
+    : "GBP"; // set in .env?
+  const currencyCode = getCurrencySymbol(currencySymbol);
 
   return (
     <Layout>


### PR DESCRIPTION
This gets the search page running once built instead of throwing undefined errors.

There are still issues I'm noticing.

1. The search page isn't populated with all products on first load.
2. Product links from the search page results have an extra slash in the URI. e.g. "http://www.dev.org/products//cuboid".
3. Clicking "View empty products" link from an empty cart page loads the search page but doesn't populate it with products.  Perhaps the query string needs to be populated with a wildcard (*) somewhere?  Perhaps this is related to point 1.
4. Once deployed there isn't a compiled search page to land on when refreshing the browser at the "/search" URI.  I'm using mod_rewrite to redirect to "index.html" however the default routing means the user is redirected to the home page anyway when trying to load "/search..." fresh in the browser.