### PR TITLE
Migrate to Head API

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,6 @@ module.exports = {
     siteTitle: "gatsby-starter-shopify",
     siteTitleDefault: "gatsby-starter-shopify by @GatsbyJS",
     siteUrl: "https://shopify-demo.gatsbyjs.com",
-    hrefLang: "en",
     siteDescription:
       "A Gatsby starter using the latest Shopify plugin showcasing a store with product overview, individual product pages, and a cart.",
     siteImage: "/default-og-image.jpg",
@@ -26,7 +25,6 @@ module.exports = {
     "gatsby-plugin-image",
     "gatsby-plugin-sharp",
     "gatsby-transformer-sharp",
-    "gatsby-plugin-react-helmet",
     "gatsby-plugin-sitemap",
     "gatsby-plugin-gatsby-cloud",
     // Add your Google Analytics ID to the .env file to enable

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,3 @@
+exports.onRenderBody = ({ setHtmlAttributes }) => {
+  setHtmlAttributes({ lang: "en" })
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@sindresorhus/slugify": "^1.1.0",
     "debounce": "^1.2.1",
     "dotenv": "^10.0.0",
-    "gatsby": "^4.0.2",
+    "gatsby": "^4.19.0",
     "gatsby-plugin-gatsby-cloud": "^4.0.0",
     "gatsby-plugin-google-analytics": "^4.0.0",
     "gatsby-plugin-image": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "gatsby-plugin-gatsby-cloud": "^4.0.0",
     "gatsby-plugin-google-analytics": "^4.0.0",
     "gatsby-plugin-image": "^2.0.0",
-    "gatsby-plugin-react-helmet": "^5.0.0",
     "gatsby-plugin-sharp": "^4.0.0",
     "gatsby-plugin-sitemap": "^5.0.0",
     "gatsby-source-filesystem": "^4.0.0",
@@ -39,7 +38,6 @@
     "query-string": "^7.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-helmet": "^6.1.0",
     "react-icons": "^4.1.0",
     "shopify-buy": "^2.11.0",
     "urql": "^2.0.2"

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -2,12 +2,10 @@ import * as React from "react"
 import { SkipNavContent, SkipNavLink } from "./skip-nav"
 import { Header } from "./header"
 import { Footer } from "./footer"
-import { Seo } from "./seo"
 
 export function Layout({ children }) {
   return (
     <div>
-      <Seo />
       <SkipNavLink />
       <Header />
       <SkipNavContent>{children}</SkipNavContent>

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 import { useLocation } from "@reach/router"
 
@@ -20,7 +19,6 @@ export function Seo({
           siteTitle
           siteTitleDefault
           siteUrl
-          hrefLang
           siteDescription
           siteImage
           twitter
@@ -35,7 +33,6 @@ export function Seo({
     siteUrl,
     siteDescription,
     siteImage,
-    hrefLang,
     twitter,
   } = siteMetadata
 
@@ -47,12 +44,8 @@ export function Seo({
   }
 
   return (
-    <Helmet
-      title={title}
-      defaultTitle={siteTitleDefault}
-      titleTemplate={`%s | ${siteTitle}`}
-    >
-      <html lang={hrefLang} />
+    <>
+      <title> {title ? `${title} | ${siteTitle}`: siteTitleDefault}</title>
       <meta name="description" content={seo.description} />
       <meta name="image" content={seo.image} />
       <meta property="og:title" content={seo.title} />
@@ -91,6 +84,6 @@ export function Seo({
         />
       )}
       {children}
-    </Helmet>
+    </>
   )
 }

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Layout } from "../components/layout"
 import { heading, paragraph, container } from "./404.module.css"
+import { Seo } from "../components/seo"
 
 export default function NotFoundPage() {
   return (
@@ -14,3 +15,5 @@ export default function NotFoundPage() {
     </Layout>
   )
 }
+
+export const Head = () => <Seo />

--- a/src/pages/cart.jsx
+++ b/src/pages/cart.jsx
@@ -20,6 +20,7 @@ import {
   emptyStateLink,
   title,
 } from "./cart.module.css"
+import { Seo } from "../components/seo"
 
 export default function CartPage() {
   const { checkout, loading } = React.useContext(StoreContext)
@@ -119,3 +120,5 @@ export default function CartPage() {
     </Layout>
   )
 }
+
+export const Head = () => <Seo />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { graphql } from "gatsby"
 import { Layout } from "../components/layout"
 import { ProductListing } from "../components/product-listing"
+import { Seo } from "../components/seo"
 import {
   container,
   intro,
@@ -55,3 +56,5 @@ export default function IndexPage({ data }) {
     </Layout>
   )
 }
+
+export const Head = () => <Seo />

--- a/src/pages/products/index.jsx
+++ b/src/pages/products/index.jsx
@@ -9,7 +9,6 @@ import { title } from "./index.module.css"
 export default function Products({ data: { products } }) {
   return (
     <Layout>
-      <Seo title="All Products" />
       <h1 className={title}>Products</h1>
       <ProductListing products={products.nodes} />
       {products.pageInfo.hasNextPage && (
@@ -18,6 +17,8 @@ export default function Products({ data: { products } }) {
     </Layout>
   )
 }
+
+export const Head = () => <Seo title="All Products" />
 
 export const query = graphql`
   {

--- a/src/pages/products/vendor/{ShopifyProduct.vendor}.jsx.example
+++ b/src/pages/products/vendor/{ShopifyProduct.vendor}.jsx.example
@@ -13,7 +13,6 @@ export default function Products({
 }) {
   return (
     <Layout>
-      <Seo title={`${vendor} products`} />
       <h1 className={title}>{vendor}</h1>
       <ProductListing products={products.nodes} />
       {products.pageInfo.hasNextPage && (
@@ -22,6 +21,12 @@ export default function Products({
         </MoreButton>
       )}
     </Layout>
+  )
+}
+
+export const Head = ({ pageContext: { vendor } }) => {
+  return (
+    <Seo title={`${vendor} products`} />
   )
 }
 

--- a/src/pages/products/{ShopifyProduct.productType}/index.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/index.jsx
@@ -13,7 +13,6 @@ export default function ProductTypeIndex({
 }) {
   return (
     <Layout>
-      <Seo title={`Category: ${productType}`} />
       <h1 className={title}>{productType}</h1>
       <ProductListing products={products.nodes} />
       {products.pageInfo.hasNextPage && (
@@ -24,6 +23,10 @@ export default function ProductTypeIndex({
     </Layout>
   )
 }
+
+export const Head = ({ pageContext: { productType } }) => (
+  <Seo title={`Category: ${productType}`} />
+)
 
 export const query = graphql`
   query($productType: String!) {

--- a/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
+++ b/src/pages/products/{ShopifyProduct.productType}/{ShopifyProduct.handle}.jsx
@@ -38,7 +38,6 @@ export default function Product({ data: { product, suggestions } }) {
     title,
     description,
     images,
-    images: [firstImage],
   } = product
   const { client } = React.useContext(StoreContext)
 
@@ -104,13 +103,6 @@ export default function Product({ data: { product, suggestions } }) {
 
   return (
     <Layout>
-      {firstImage ? (
-        <Seo
-          title={title}
-          description={description}
-          image={getSrc(firstImage.gatsbyImageData)}
-        />
-      ) : undefined}
       <div className={container}>
         <div className={productBox}>
           {hasImages && (
@@ -211,6 +203,26 @@ export default function Product({ data: { product, suggestions } }) {
         </div>
       </div>
     </Layout>
+  )
+}
+
+export const Head = ({ data: { product } }) => {
+  const {
+    title,
+    description,
+    images: [firstImage],
+  } = product
+
+  return (
+    <>
+      {firstImage ? (
+        <Seo
+          title={title}
+          description={description}
+          image={getSrc(firstImage.gatsbyImageData)}
+        />
+      ) : undefined}
+    </>
   )
 }
 

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -39,6 +39,7 @@ import {
   filterWrap,
   emptyState,
 } from "./search-page.module.css"
+import { Seo } from "../components/seo"
 
 const DEFAULT_PRODUCTS_PER_PAGE = 24
 
@@ -335,3 +336,5 @@ export default function SearchPageTemplate(props) {
     </SearchProvider>
   )
 }
+
+export const Head = () => <Seo/>


### PR DESCRIPTION
## Description 

Migrates this starter to use the new [Gatsby Head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/)

[sc-52184]